### PR TITLE
Hotfix/support nullable types in marshalling

### DIFF
--- a/Jint.Tests/Fixtures.cs
+++ b/Jint.Tests/Fixtures.cs
@@ -489,26 +489,14 @@ bar');
         public void ShouldHandleNullableValueTypes()
         {
             const string script = @"
-                assertIsNull(null);
-                assertIsNull(undefined);
-                assertIsNotNull(1);
-
-                var i;
-                assertIsNull(i);
-
-                i = null;
-                assertIsNull(i);
-
-                i = undefined;
-                assertIsNull(i);
-
-                i = 1;
-                assertIsNotNull(i);
+                result.Int32 = input ? ToInt32(input) : null;
             ";
 
+            var result = new TypeWithNullableValueTypeProperty();
+
             new JintEngine()
-                .SetFunction("assertIsNull", new Action<double?>((a) => Assert.IsNull(a)))
-                .SetFunction("assertIsNotNull", new Action<double?>((a) => Assert.IsNotNull(a)))
+                .SetParameter("input", "")
+                .SetParameter("result", result)
                 .Run(script);
         }
 
@@ -1810,5 +1798,10 @@ var fakeButton = new Test.FakeButton();");
         public void Write(object value) {
             Console.WriteLine(value);
         }
+    }
+
+    public class TypeWithNullableValueTypeProperty
+    {
+        public int? Int32 { get; set; }
     }
 }

--- a/Jint.Tests/Fixtures.cs
+++ b/Jint.Tests/Fixtures.cs
@@ -471,7 +471,8 @@ bar');
         }
 
         [TestMethod]
-        public void ShouldAllowSecuritySandBox() {
+        public void ShouldAllowSecuritySandBox()
+        {
             var userDirectory = Path.GetTempPath();
 
             const string script = @"
@@ -481,6 +482,33 @@ bar');
             new JintEngine()
                 .SetParameter("userDir", userDirectory)
                 .AddPermission(new FileIOPermission(FileIOPermissionAccess.PathDiscovery, userDirectory))
+                .Run(script);
+        }
+
+        [TestMethod]
+        public void ShouldHandleNullableValueTypes()
+        {
+            const string script = @"
+                assertIsNull(null);
+                assertIsNull(undefined);
+                assertIsNotNull(1);
+
+                var i;
+                assertIsNull(i);
+
+                i = null;
+                assertIsNull(i);
+
+                i = undefined;
+                assertIsNull(i);
+
+                i = 1;
+                assertIsNotNull(i);
+            ";
+
+            new JintEngine()
+                .SetFunction("assertIsNull", new Action<double?>((a) => Assert.IsNull(a)))
+                .SetFunction("assertIsNotNull", new Action<double?>((a) => Assert.IsNotNull(a)))
                 .Run(script);
         }
 

--- a/Jint.Tests/Fixtures.cs
+++ b/Jint.Tests/Fixtures.cs
@@ -487,17 +487,45 @@ bar');
         [TestMethod]
         public void ShouldHandleNullableValueTypes() {
             const string script = @"
-                result.Int32 = input ? ToInt32(input) : null;
+                result.NullableInt32 = input ? ToInt32(input) : null;
+                result.String = null;
             ";
 
-            var result = new TypeWithNullableValueTypeProperty();
+            var result = new TypeWithNullableValueTypeProperty
+            {
+                NullableInt32 = 1,
+                String = "",
+            };
 
             new JintEngine()
                 .SetParameter("input", "")
                 .SetParameter("result", result)
                 .Run(script);
+
+            Assert.IsNull(result.NullableInt32);
+            Assert.IsNull(result.String);
         }
 
+        [TestMethod]
+        public void ShouldHandleNonNullableValueTypes()
+        {
+            const string script = @"
+                result.Int32 = null;
+            ";
+
+            var result = new TypeWithNullableValueTypeProperty();
+
+            try
+            {
+                new JintEngine()
+                        .SetParameter("result", result)
+                        .Run(script);
+            }
+            catch (JintException je)
+            {
+                Assert.IsTrue(je.Message.Contains("Cannot cast null value to Int32"));
+            }
+        }
 
         [TestMethod]
         public void ShouldSetClrProperties() {
@@ -1800,6 +1828,8 @@ var fakeButton = new Test.FakeButton();");
 
     public class TypeWithNullableValueTypeProperty
     {
-        public int? Int32 { get; set; }
+        public int Int32 { get; set; }
+        public int? NullableInt32 { get; set; }
+        public string String { get; set; }
     }
 }

--- a/Jint.Tests/Fixtures.cs
+++ b/Jint.Tests/Fixtures.cs
@@ -471,8 +471,7 @@ bar');
         }
 
         [TestMethod]
-        public void ShouldAllowSecuritySandBox()
-        {
+        public void ShouldAllowSecuritySandBox() {
             var userDirectory = Path.GetTempPath();
 
             const string script = @"
@@ -486,8 +485,7 @@ bar');
         }
 
         [TestMethod]
-        public void ShouldHandleNullableValueTypes()
-        {
+        public void ShouldHandleNullableValueTypes() {
             const string script = @"
                 result.Int32 = input ? ToInt32(input) : null;
             ";

--- a/Jint/Marshal.cs
+++ b/Jint/Marshal.cs
@@ -204,7 +204,12 @@ namespace Jint
         public T MarshalJsValue<T>(JsInstance value)
         {
             if (value == JsNull.Instance || value == JsUndefined.Instance)
-                return default(T);
+            {
+                if (!typeof(T).IsValueType || typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(Nullable<>))
+                    return default(T);
+
+                throw new JintException(string.Format("Cannot cast null value to {0}", typeof(T).Name));
+            }
 
             if (value.Value is T)
                 return (T)value.Value;

--- a/Jint/Marshal.cs
+++ b/Jint/Marshal.cs
@@ -203,54 +203,43 @@ namespace Jint
         /// <returns>A converted native velue</returns>
         public T MarshalJsValue<T>(JsInstance value)
         {
+            if (value == JsNull.Instance || value == JsUndefined.Instance)
+                return default(T);
+
             if (value.Value is T)
-            {
                 return (T)value.Value;
-            }
-            else
+            
+            if (typeof(T).IsArray)
             {
-                if (typeof(T).IsArray)
-                {
-                    if (value == null || value == JsUndefined.Instance || value == JsNull.Instance)
-                        return default(T);
-                    if (m_global.ArrayClass.HasInstance(value as JsObject))
-                    {
-                        Delegate marshller;
-                        if (!m_arrayMarshllers.TryGetValue(typeof(T), out marshller))
-                            m_arrayMarshllers[typeof(T)] = marshller = Delegate.CreateDelegate(
-                                typeof(Delegates.Func<JsObject, T>),
-                                this,
-                                typeof(Marshaller)
-                                    .GetMethod("MarshalJsFunctionHelper")
-                                    .MakeGenericMethod(typeof(T).GetElementType())
-                            );
+                if (!m_global.ArrayClass.HasInstance(value as JsObject))
+                    throw new JintException("Array is required");
 
-                        return ((Delegates.Func<JsObject, T>)marshller)(value as JsObject);
-                    }
-                    else
-                    {
-                        throw new JintException("Array is required");
-                    }
-                }
-                else if (typeof(Delegate).IsAssignableFrom(typeof(T)))
-                {
-                    if (value == null || value == JsUndefined.Instance || value == JsNull.Instance)
-                        return default(T);
+                Delegate marshller;
+                if (!m_arrayMarshllers.TryGetValue(typeof(T), out marshller))
+                    m_arrayMarshllers[typeof(T)] = marshller = Delegate.CreateDelegate(
+                        typeof(Delegates.Func<JsObject, T>),
+                        this,
+                        typeof(Marshaller)
+                            .GetMethod("MarshalJsFunctionHelper")
+                            .MakeGenericMethod(typeof(T).GetElementType())
+                        );
 
-                    if (! (value is JsFunction) )
-                        throw new JintException("Can't convert a non function object to a delegate type");
-                    return (T)MarshalJsFunctionHelper(value as JsFunction, typeof(T));
-                }
-                else if (value != JsNull.Instance && value != JsUndefined.Instance && value is T)
-                {
-                    return (T)(object)value;
-                }
-                else
-                {
-                    // JsNull and JsUndefined will fall here and become a nulls
-                    return (T)Convert.ChangeType(value.Value, typeof(T));
-                }
+                return ((Delegates.Func<JsObject, T>)marshller)(value as JsObject);
             }
+            
+            if (typeof(Delegate).IsAssignableFrom(typeof(T)))
+            {
+                if (! (value is JsFunction) )
+                    throw new JintException("Can't convert a non function object to a delegate type");
+                return (T)MarshalJsFunctionHelper(value as JsFunction, typeof(T));
+            }
+            
+            if (value is T)
+            {
+                return (T)(object)value;
+            }
+
+            return (T)Convert.ChangeType(value.Value, typeof(T));
         }
 
         /// <summary>


### PR DESCRIPTION
While using Jint at ScoreBig, we found an issue where nullable value types were not being marshalled properly, resulting in the following exception:

``` c#
System.InvalidCastException: Null object cannot be converted to a value type.
   at System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)
   at Jint.Marshaller.MarshalJsValue[T](JsInstance value)
   at dynamicPropertySetter(Marshaller , JsDictionaryObject , JsInstance )
   at Jint.ExecutionVisitor.Assign(MemberExpression left, JsInstance value)
   at Jint.ExecutionVisitor.Visit(AssignmentExpression statement)
   at Jint.ExecutionVisitor.Visit(BlockStatement statement)
   at Jint.Native.JsFunction.Execute(IJintVisitor visitor, JsDictionaryObject that, JsInstance[] parameters)
   at Jint.ExecutionVisitor.ExecuteFunction(JsFunction function, JsDictionaryObject that, JsInstance[] parameters, Type[] genericParameters)
   at Jint.ExecutionVisitor.Visit(MethodCall methodCall)
   at Jint.ExecutionVisitor.Visit(MemberExpression expression)
```

This exception occurs when attempting to assign a null value to a nullable property because Convert.ChangeType doesn't handle nullable values well. I've updated the MarshalJsValue method to return default(T) in the case of JsNull and JsUndefined values, and cleaned up the type conversion logic a little. (There were several places where JsNull and JsUndefined were being checked, which didn't seem to be necessary if it was handled first.)

I love Jint, and I hope you find this PR useful.
